### PR TITLE
fix memory leak

### DIFF
--- a/plane_seg_ros/src/plane_seg_ros.cpp
+++ b/plane_seg_ros/src/plane_seg_ros.cpp
@@ -471,7 +471,7 @@ int main( int argc, char** argv ){
 
   ros::init(argc, argv, "plane_seg");
   ros::NodeHandle nh("~");
-  Pass *app = new Pass(nh);
+  std::unique_ptr<Pass> app = std::make_unique<Pass>(nh);
 
   ROS_INFO_STREAM("plane_seg ros ready");
   ROS_INFO_STREAM("=============================");


### PR DESCRIPTION
This PR fixes a trivial memory leak.

Valgrind Before:
```
==12974== LEAK SUMMARY:
==12974==    definitely lost: 0 bytes in 0 blocks
==12974==    indirectly lost: 0 bytes in 0 blocks
==12974==      possibly lost: 864 bytes in 2 blocks
==12974==    still reachable: 108,923 bytes in 1,082 blocks
==12974==         suppressed: 0 bytes in 0 blocks
==12974== 
==12974== For counts of detected and suppressed errors, rerun with: -v
==12974== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

Valgrind After:
```
==13204== LEAK SUMMARY:
==13204==    definitely lost: 0 bytes in 0 blocks
==13204==    indirectly lost: 0 bytes in 0 blocks
==13204==      possibly lost: 0 bytes in 0 blocks
==13204==    still reachable: 58,262 bytes in 841 blocks
==13204==         suppressed: 0 bytes in 0 blocks
==13204== 
==13204== For counts of detected and suppressed errors, rerun with: -v
==13204== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
